### PR TITLE
added buildArch option, console.log for errors

### DIFF
--- a/lib/rpmbuild.js
+++ b/lib/rpmbuild.js
@@ -39,6 +39,7 @@ function init(opts, cb){
     var ctx = {
         spec: spec,
         specTemplate: opts.specTemplate || SPEC_TEMPLATE,
+        buildArch: opts.buildArch || 'noarch',
         cwd: cwd,
         fullname: opts.name + '-' + opts.version,
         _files: opts.files,
@@ -73,6 +74,7 @@ function writeSpec(ctx, cb){
     var args = {
         summary: specOpts.summary,
         name: specOpts.name,
+        buildArch: ctx.buildArch,
         version: specOpts.version,
         release: specOpts.release,
         description: specOpts.description,

--- a/lib/util.js
+++ b/lib/util.js
@@ -22,6 +22,7 @@ function rpmbuild(specFile, rpmRoot, opts, cb){
     var rpms = { rpm: null, srpm: null };
     exec(cmd, { cwd: rpmRoot }, function (error, stdout, stderr) {
         if (error) {
+            console.log(error);
             cb('rpmbuild failed, exit code '+error.code);
         }
         

--- a/spec
+++ b/spec
@@ -15,6 +15,8 @@ URL: {{url}}
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
+BuildArch: {{buildArch}}
+
 %description
 {{description}}
 


### PR DESCRIPTION
Great work on this, worked pretty well for me. 

The only problem I ran into was folder permissions on the /opt.. /tmp directory - it kept saying it could not access the temp file without sudo access. I don't know if it's due to the logic here, or due to the rpmbuild install process on mac that required sudo. I was able to fix it though by changing the permissions on the tmp dir.
