### PR TITLE
fix rpmbuild under shells that don't support {} expansion

### DIFF
--- a/lib/rpmbuild.js
+++ b/lib/rpmbuild.js
@@ -103,7 +103,8 @@ function writeSpec(ctx, cb){
 // setup the RPM directory structure
 function setupRpmRoot(ctx, cb){
     mod.emit('message', 'setupRpmRoot', ctx.rpmRootDir);
-    var root = path.join(ctx.rpmRootDir, '/{RPMS,SRPMS,BUILD,SOURCES,SPECS,tmp}');
+    var root = ['RPMS', 'SRPMS', 'BUILD', 'SOURCES', 'SPECS', 'tmp']
+        .map(function(d) { return path.join(ctx.rpmRootDir, d); }).join(' ');
     xutil.mkdirp(root, function(err){ cb(err, ctx); });
 }
 


### PR DESCRIPTION
Creating the rpmroot directories used {} expansion which relies on the shell supporting it.  Node always seems to use /bin/sh in linux and in ubuntu that's a symlink to dash not bash.

I've modified it to do the expansion in js so which shell is used doesn't matter.
